### PR TITLE
feat: Auto-fetch word details (meaning, example, level) when manually…

### DIFF
--- a/LingRootMobile/src/contexts/AuthContext.tsx
+++ b/LingRootMobile/src/contexts/AuthContext.tsx
@@ -51,6 +51,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           full_name: (builtFullName && builtFullName.length > 0) ? builtFullName : (authUser.email?.split('@')[0] || ''),
           avatar_url: umd.avatar_url,
           membership_level: umd.membership_level || 'free',
+          role: umd.role,
           created_at: authUser.created_at,
           updated_at: authUser.updated_at || authUser.created_at,
         };
@@ -138,6 +139,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                   [su.firstname, su.lastname].filter(Boolean).join(' ')
                 )?.toString().trim();
                 appUser.full_name = (built && built.length > 0) ? built : (appUser.full_name || appUser.email?.split('@')[0] || '');
+                appUser.role = su.role;
                 await AsyncStorage.setItem('user_data', JSON.stringify(appUser));
               } else {
                 if (!appUser.full_name || (appUser.full_name as any)?.toString().trim().length === 0) {
@@ -250,6 +252,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           full_name: builtFullName && builtFullName.length > 0 ? builtFullName : (backendUser.email?.split('@')[0] || ''),
           avatar_url: backendUser.avatar_url,
           membership_level: backendUser.membership_status || 'free',
+          role: backendUser.role,
           created_at: backendUser.created_at,
           updated_at: backendUser.updated_at,
         };

--- a/LingRootMobile/src/screens/AccountSettingsScreen.tsx
+++ b/LingRootMobile/src/screens/AccountSettingsScreen.tsx
@@ -3,7 +3,6 @@ import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert, KeyboardAvo
 import { useAuth } from '../contexts/AuthContext';
 import { apiService } from '../services/api';
 import { useLanguage } from '../contexts/LanguageContext';
-import { IAP_PRODUCTS, requestSubscription, restorePurchases } from '../services/iap';
 
 // Phone helpers: Turkish format +90 555 123 45 67
 const extractDigits = (value: string) => (value || '').replace(/\D+/g, '');
@@ -136,40 +135,6 @@ const AccountSettingsScreen: React.FC = () => {
         <TouchableOpacity style={[styles.button, (!isValid || isSaving) && styles.buttonDisabled]} onPress={onSave} disabled={!isValid || isSaving}>
           <Text style={styles.buttonText}>{isSaving ? savingLabel : saveLabel}</Text>
         </TouchableOpacity>
-
-        <View style={[styles.section, { marginTop: 16 }]}>
-          <Text style={[styles.label, { marginBottom: 8 }]}>Abonelik</Text>
-
-          <TouchableOpacity
-            style={styles.button}
-            onPress={async () => {
-              const res = await requestSubscription(IAP_PRODUCTS.goldMonthly);
-              Alert.alert(res.ok ? 'Başarılı' : 'Hata', res.message || (res.ok ? 'Gold (Aylık) abonelik etkinleştirildi' : 'Satın alma başarısız'));
-            }}
-          >
-            <Text style={styles.buttonText}>Gold (Aylık) Satın Al</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.button, { marginTop: 10 }]}
-            onPress={async () => {
-              const res = await requestSubscription(IAP_PRODUCTS.platinumMonthly);
-              Alert.alert(res.ok ? 'Başarılı' : 'Hata', res.message || (res.ok ? 'Platinum (Aylık) abonelik etkinleştirildi' : 'Satın alma başarısız'));
-            }}
-          >
-            <Text style={styles.buttonText}>Platinum (Aylık) Satın Al</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity
-            style={[styles.buttonSecondary, { marginTop: 10 }]}
-            onPress={async () => {
-              const res = await restorePurchases();
-              Alert.alert(res.ok ? 'Başarılı' : 'Hata', res.message || (res.ok ? 'Satın alımlar geri yüklendi' : 'Geri yükleme başarısız'));
-            }}
-          >
-            <Text style={styles.buttonSecondaryText}>Satın Alımları Geri Yükle</Text>
-          </TouchableOpacity>
-        </View>
       </ScrollView>
     </KeyboardAvoidingView>
   );

--- a/LingRootMobile/src/screens/PackagesScreen.tsx
+++ b/LingRootMobile/src/screens/PackagesScreen.tsx
@@ -133,7 +133,7 @@ const PackagesScreen: React.FC = () => {
   };
 
   const formatPrice = (price: number) => {
-    return `₹${price}`;
+    return `₺${price}`;
   };
 
   const formatFeatures = (features?: string[]) => {

--- a/LingRootMobile/src/screens/ProfileScreen.tsx
+++ b/LingRootMobile/src/screens/ProfileScreen.tsx
@@ -132,19 +132,22 @@ ${!status.isInitialized ? `\n⚠️ ${language === 'tr' ? 'Servis başlatılmam�
     }
   };
 
+  // Check if user is admin
+  const isAdmin = user?.role === 'admin';
+
   const menuItems = [
     { id: 1, title: t('profile.accountSettings'), icon: 'settings', action: () => navigation.navigate('Settings') },
     { id: 1.5, title: t('profile.language'), icon: 'language', action: () => setLanguageModalVisible(true) },
-    { id: 2, title: t('profile.audioHistory'), icon: 'history', action: () => {} },
     { id: 3, title: language === 'tr' ? 'Kalan Kullanım' : 'Remaining Usage', icon: 'assessment', action: () => navigation.navigate('Membership') },
     { id: 3.2, title: language === 'tr' ? 'Paket Bilgileri' : 'Package Information', icon: 'inventory', action: () => navigation.navigate('Packages') },
     { id: 3.5, title: 'Mesaj Gönder', icon: 'chat', action: () => navigation.navigate('Chat') },
-    { id: 3.8, title: language === 'tr' ? 'Bildirim Ayarlarını Aç' : 'Open Notification Settings', icon: 'notifications-none', action: handleOpenNotificationSettings },
-    { id: 4, title: t('profile.testNotification'), icon: 'notifications', action: handleTestNotification },
-    { id: 5, title: t('profile.notificationStatus'), icon: 'notifications-active', action: handleNotificationStatus },
-    { id: 8, title: t('profile.quickDebug'), icon: 'bug-report', action: handleQuickDebug },
-    { id: 6, title: t('profile.help'), icon: 'help', action: () => {} },
-    { id: 7, title: t('profile.about'), icon: 'info', action: () => {} },
+    // Admin-only menu items
+    ...(isAdmin ? [
+      { id: 3.8, title: language === 'tr' ? 'Bildirim Ayarlarını Aç' : 'Open Notification Settings', icon: 'notifications-none', action: handleOpenNotificationSettings },
+      { id: 4, title: t('profile.testNotification'), icon: 'notifications', action: handleTestNotification },
+      { id: 5, title: t('profile.notificationStatus'), icon: 'notifications-active', action: handleNotificationStatus },
+      { id: 8, title: t('profile.quickDebug'), icon: 'bug-report', action: handleQuickDebug },
+    ] : []),
   ];
 
   return (

--- a/LingRootMobile/src/screens/VocabularyScreen.tsx
+++ b/LingRootMobile/src/screens/VocabularyScreen.tsx
@@ -18,7 +18,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { 
   getVocabulary, 
-  addWordToVocabulary, 
+  addWordToVocabulary,
+  addWordWithTranslation,
   deleteWordFromVocabulary, 
   updateWordInVocabulary,
   VocabularyWord,
@@ -317,23 +318,46 @@ export default function VocabularyScreen({ navigation, route }: any) {
   };
 
   const addNewWord = async () => {
-    if (!newWord.word || !newWord.definition) {
-      Alert.alert('Hata', 'Kelime ve anlam alanları zorunludur.');
+    if (!newWord.word) {
+      Alert.alert('Hata', 'Kelime alanı zorunludur.');
       return;
     }
 
     try {
-      const addedWord = await addWordToVocabulary(
-        newWord.word,
-        newWord.definition,
-        newWord.example || undefined,
-        newWord.level.toUpperCase()
+      const cleanWord = newWord.word.trim();
+      
+      // Otomatik olarak kelime detaylarını çek (AudioPlayer'daki gibi)
+      const result = await addWordWithTranslation(
+        cleanWord,
+        '', // Context boş olabilir, API kendi context'ini oluşturur
+        newWord.level.toUpperCase(),
+        '' // Original sentence boş olabilir
       );
 
-      setVocabulary([...vocabulary, addedWord]);
+      setVocabulary([...vocabulary, result.data]);
       setNewWord({ word: '', definition: '', level: 'a1', example: '' });
       setIsAddModalVisible(false);
-      Alert.alert('Başarılı', 'Kelime başarıyla eklendi!');
+      
+      // Detaylı başarı mesajı göster
+      if (result.isExisting) {
+        Alert.alert(
+          'Bilgi!',
+          `"${cleanWord}" kelimesi zaten kelime listenizdedir:\n\nAnlam: ${result.data.definition || 'Belirtilmemiş'}\nÖrnek: ${result.data.example_sentence || 'Belirtilmemiş'}`,
+          [{ text: 'Tamam' }]
+        );
+      } else if (result.translationError) {
+        Alert.alert(
+          'Uyarı!',
+          `"${cleanWord}" kelimesi eklendi ancak çeviri yapılamadı. Anlamı manuel olarak ekleyebilirsiniz.`,
+          [{ text: 'Tamam' }]
+        );
+      } else {
+        Alert.alert(
+          'Başarılı!',
+          `"${cleanWord}" kelimesi başarıyla eklendi!\n\nAnlam: ${result.data.definition}\nÖrnek Cümle: ${result.data.example_sentence}\nSeviye: ${result.data.level}`,
+          [{ text: 'Tamam' }]
+        );
+      }
     } catch (error: any) {
       Alert.alert('Hata', 'Kelime eklenirken hata oluştu: ' + error.message);
     }
@@ -661,20 +685,13 @@ export default function VocabularyScreen({ navigation, route }: any) {
                 onChangeText={(text) => setNewWord({...newWord, word: text})}
                 placeholder="Örn: beautiful"
               />
+              <Text style={styles.helperText}>
+                💡 Anlam, örnek cümle ve seviye otomatik olarak çekilecektir
+              </Text>
             </View>
             
             <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Anlam *</Text>
-              <TextInput
-                style={styles.textInput}
-                value={newWord.definition}
-                onChangeText={(text) => setNewWord({...newWord, definition: text})}
-                placeholder="Örn: güzel, hoş"
-              />
-            </View>
-            
-            <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Seviye</Text>
+              <Text style={styles.inputLabel}>Seviye (Varsayılan)</Text>
               <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                 {Object.entries(wordLevels).map(([level, data]) => (
                   <TouchableOpacity
@@ -696,18 +713,9 @@ export default function VocabularyScreen({ navigation, route }: any) {
                   </TouchableOpacity>
                 ))}
               </ScrollView>
-            </View>
-            
-            <View style={styles.inputGroup}>
-              <Text style={styles.inputLabel}>Örnek Cümle</Text>
-              <TextInput
-                style={[styles.textInput, styles.textArea]}
-                value={newWord.example}
-                onChangeText={(text) => setNewWord({...newWord, example: text})}
-                placeholder="Örn: She is very beautiful."
-                multiline
-                numberOfLines={3}
-              />
+              <Text style={styles.helperText}>
+                Seviye AI tarafından otomatik belirlenecektir
+              </Text>
             </View>
           </ScrollView>
         </SafeAreaView>
@@ -1148,6 +1156,12 @@ const styles = StyleSheet.create({
   levelSelectorText: {
     fontSize: 14,
     fontWeight: '600',
+  },
+  helperText: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginTop: 8,
+    fontStyle: 'italic',
   },
   authContainer: {
     flex: 1,

--- a/LingRootMobile/src/types/index.ts
+++ b/LingRootMobile/src/types/index.ts
@@ -5,6 +5,7 @@ export interface User {
   full_name?: string;
   avatar_url?: string;
   membership_level: MembershipLevel;
+  role?: string;
   created_at: string;
   updated_at: string;
 }

--- a/frontend/pages/vocabulary.tsx
+++ b/frontend/pages/vocabulary.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getVocabulary, deleteWordFromVocabulary, updateWordInVocabulary, addWordToVocabulary, VocabularyWord, getReminderSettings, saveReminderSettings, ReminderSettings } from '../src/lib/api';
+import { getVocabulary, deleteWordFromVocabulary, updateWordInVocabulary, addWordToVocabulary, addWordWithTranslation, VocabularyWord, getReminderSettings, saveReminderSettings, ReminderSettings } from '../src/lib/api';
 import { Button } from "../src/components/ui/button";
 import { Input } from "../src/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "../src/components/ui/card";
@@ -146,15 +146,28 @@ export function VocabularyTabContent({ user }: { user: any }) {
   const handleAddWord = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await addWordToVocabulary(
-        newWord.word, 
-        newWord.meaning, 
-        newWord.example, 
-        newWord.level.toUpperCase()
+      const cleanWord = newWord.word.trim();
+      
+      // Otomatik olarak kelime detaylarını çek (AudioPlayer ve mobil uygulama gibi)
+      const result = await addWordWithTranslation(
+        cleanWord,
+        '', // Context boş olabilir, API kendi context'ini oluşturur
+        newWord.level.toUpperCase(),
+        '' // Original sentence boş olabilir
       );
+      
       setNewWord({ word: "", level: "a1", meaning: "", example: "" });
       setIsAddWordModalOpen(false);
       loadVocabulary();
+      
+      // Detaylı başarı mesajı göster
+      if (result.isExisting) {
+        alert(`Bilgi!\n\n"${cleanWord}" kelimesi zaten kelime listenizdedir:\n\nAnlam: ${result.data.definition || 'Belirtilmemiş'}\nÖrnek: ${result.data.example_sentence || 'Belirtilmemiş'}`);
+      } else if (result.translationError) {
+        alert(`Uyarı!\n\n"${cleanWord}" kelimesi eklendi ancak çeviri yapılamadı. Anlamı manuel olarak ekleyebilirsiniz.`);
+      } else {
+        alert(`Başarılı!\n\n"${cleanWord}" kelimesi başarıyla eklendi!\n\nAnlam: ${result.data.definition}\nÖrnek Cümle: ${result.data.example_sentence}\nSeviye: ${result.data.level}`);
+      }
     } catch (error: any) {
       alert('Kelime eklenirken hata oluştu: ' + error.message);
     }
@@ -269,19 +282,23 @@ export function VocabularyTabContent({ user }: { user: any }) {
                 </Button>
               </div>
               <form onSubmit={handleAddWord} className="space-y-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4">
                   <div>
-                    <Label htmlFor="word">Kelime</Label>
+                    <Label htmlFor="word">Kelime *</Label>
                     <Input
                       id="word"
                       value={newWord.word}
                       onChange={(e) => setNewWord({...newWord, word: e.target.value})}
                       className="mt-1"
+                      placeholder="Örn: beautiful"
                       required
                     />
+                    <p className="text-sm text-gray-500 mt-2 italic">
+                      💡 Anlam, örnek cümle ve seviye otomatik olarak çekilecektir
+                    </p>
                   </div>
                   <div>
-                    <Label htmlFor="level">Seviye</Label>
+                    <Label htmlFor="level">Seviye (Varsayılan)</Label>
                     <select
                       id="level"
                       value={newWord.level}
@@ -295,25 +312,9 @@ export function VocabularyTabContent({ user }: { user: any }) {
                       <option value="c1">C1</option>
                       <option value="c2">C2</option>
                     </select>
-                  </div>
-                  <div className="col-span-2">
-                    <Label htmlFor="meaning">Anlam</Label>
-                    <Input
-                      id="meaning"
-                      value={newWord.meaning}
-                      onChange={(e) => setNewWord({...newWord, meaning: e.target.value})}
-                      className="mt-1"
-                      required
-                    />
-                  </div>
-                  <div className="col-span-2">
-                    <Label htmlFor="example">Örnek Cümle</Label>
-                    <Input
-                      id="example"
-                      value={newWord.example}
-                      onChange={(e) => setNewWord({...newWord, example: e.target.value})}
-                      className="mt-1"
-                    />
+                    <p className="text-sm text-gray-500 mt-2 italic">
+                      Seviye AI tarafından otomatik belirlenecektir
+                    </p>
                   </div>
                 </div>
                 <div className="flex justify-end space-x-3 mt-6">


### PR DESCRIPTION
… adding words

- Updated mobile VocabularyScreen to use addWordWithTranslation API
- Updated web vocabulary page to use addWordWithTranslation API
- Removed manual meaning and example fields from both UIs
- Added helper text to inform users about auto-fetch feature
- Consistent behavior across mobile, web, and AudioPlayer long-press
- Detailed success/error messages for better UX

Additional changes:
- Profile screen: Hide admin-only buttons (notifications, debug) from regular users
- Profile screen: Remove Help and About menu items
- Profile screen: Remove Audio History menu item
- AccountSettings: Remove subscription section
- PackagesScreen: Fix currency symbol from ₹ to ₺ (Turkish Lira)
- AuthContext: Add role field to User object for admin detection