### PR TITLE
fix: Use AI-determined level in AudioPlayer word additions

### DIFF
--- a/LingRootMobile/src/components/AudioPlayer.tsx
+++ b/LingRootMobile/src/components/AudioPlayer.tsx
@@ -441,7 +441,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
       const result = await addWordWithTranslation(
         cleanWord,
         context, // Context for AI translation
-        track.level,
+        '', // Level boş - OpenAI otomatik belirleyecek
         originalSentence
       );
 

--- a/frontend/src/components/NewSyncedTextPlayer.tsx
+++ b/frontend/src/components/NewSyncedTextPlayer.tsx
@@ -152,7 +152,7 @@ export default function NewSyncedTextPlayer({
         sentence.toLowerCase().includes(contextMenu.word.toLowerCase())
       ) || '';
       
-      const result = await addWordWithTranslation(contextMenu.word, context, level, originalSentence);
+      const result = await addWordWithTranslation(contextMenu.word, context, '', originalSentence); // Level boş - OpenAI otomatik belirleyecek
       
       console.log('Kelime başarıyla eklendi:', result);
       alert(`"${contextMenu.word}" kelimesi kelime listenize eklendi!`);

--- a/frontend/src/components/SyncedTextPlayer.tsx
+++ b/frontend/src/components/SyncedTextPlayer.tsx
@@ -924,7 +924,7 @@ export default function SyncedTextPlayer({
       }
       
       // OpenAI çevirisi ile kelime ekle
-      const result = await addWordWithTranslation(contextMenu.word, context, level, originalSentence);
+      const result = await addWordWithTranslation(contextMenu.word, context, '', originalSentence); // Level boş - OpenAI otomatik belirleyecek
       
       if (result.isExisting) {
         alert(`"${contextMenu.word}" kelimesi zaten kelime listenizdedir:\n\nAnlam: ${result.data.definition || 'Belirtilmemiş'}\nÖrnek: ${result.data.example_sentence || 'Belirtilmemiş'}`);


### PR DESCRIPTION
- Remove track.level from AudioPlayer word addition
- Remove level prop from SyncedTextPlayer word addition
- Remove level prop from NewSyncedTextPlayer word addition
- Let OpenAI determine word level based on context
- Ensures consistent AI-powered level detection across all word addition methods