### PR TITLE
feat: iOS release - Apple App Store compliance updates

### DIFF
--- a/LingRootMobile/src/components/UsageEstimateCard.tsx
+++ b/LingRootMobile/src/components/UsageEstimateCard.tsx
@@ -47,6 +47,58 @@ const UsageEstimateCard: React.FC<Props> = ({ refreshKey }) => {
 
   const perCategory = computeCostAwareEstimates(summary);
   const exceeded = !!summary?.isExceeded;
+  const isFreeTrialExhausted = !!(summary as any)?.isFreeTrialExhausted;
+  const planName = (summary as any)?.plan?.name || (summary as any)?.plantype;
+  const isFreeTrialPlan = planName === 'Free Trial';
+
+  // Free Trial için özel görünüm
+  if (isFreeTrialPlan) {
+    const audioCount = (summary as any)?.audioCreationCount || 0;
+    const maxAudioCount = (summary as any)?.maxAudioCount || 3;
+    const remainingCount = (summary as any)?.remainingAudioCount || (maxAudioCount - audioCount);
+    
+    return (
+      <View style={[styles.card, isFreeTrialExhausted && styles.cardExceeded]}>
+        <View style={styles.headerRow}>
+          <Icon name="card-giftcard" size={18} color={isFreeTrialExhausted ? '#C62828' : '#10B981'} />
+          <Text style={[styles.cardTitle, isFreeTrialExhausted && { color: '#C62828' }]}>
+            {language === 'tr' ? 'Ücretsiz Deneme' : 'Free Trial'}
+          </Text>
+        </View>
+        
+        <View style={{ marginTop: 12 }}>
+          <View style={styles.row}>
+            <Text style={styles.label}>
+              {language === 'tr' ? 'Oluşturulan Ses' : 'Created Audios'}
+            </Text>
+            <Text style={[styles.value, isFreeTrialExhausted && { color: '#C62828' }]}>
+              {audioCount} / {maxAudioCount}
+            </Text>
+          </View>
+          
+          <View style={[styles.row, { marginTop: 8 }]}>
+            <Text style={styles.label}>
+              {language === 'tr' ? 'Kalan Hak' : 'Remaining Credits'}
+            </Text>
+            <Text style={[styles.value, { color: remainingCount > 0 ? '#10B981' : '#C62828', fontSize: 18, fontWeight: '700' }]}>
+              {remainingCount}
+            </Text>
+          </View>
+        </View>
+        
+        {isFreeTrialExhausted && (
+          <View style={styles.exceededBox}>
+            <Icon name="error" size={16} color="#C62828" />
+            <Text style={styles.exceededText}>
+              {language === 'tr' 
+                ? 'Ücretsiz deneme hakkınız doldu. Premium pakete geçin.' 
+                : 'Your free trial credits are exhausted. Upgrade to premium.'}
+            </Text>
+          </View>
+        )}
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.card, exceeded && styles.cardExceeded]}>      

--- a/LingRootMobile/src/navigation/AppNavigator.tsx
+++ b/LingRootMobile/src/navigation/AppNavigator.tsx
@@ -27,6 +27,8 @@ import MembershipScreen from '../screens/MembershipScreen';
 import ChatScreen from '../screens/ChatScreen';
 import AccountSettingsScreen from '../screens/AccountSettingsScreen';
 import PackagesScreen from '../screens/PackagesScreen';
+import PrivacyPolicyScreen from '../screens/PrivacyPolicyScreen';
+import TermsOfServiceScreen from '../screens/TermsOfServiceScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
@@ -284,6 +286,28 @@ const AppNavigator = () => {
                   fontWeight: 'bold',
                 },
                 headerTitle: 'Vocabulary', // This will be updated by the component
+              }}
+            />
+            <Stack.Screen
+              name="PrivacyPolicy"
+              component={PrivacyPolicyScreen}
+              options={{
+                headerShown: true,
+                headerStyle: { backgroundColor: '#007AFF' },
+                headerTintColor: '#fff',
+                headerTitleStyle: { fontWeight: 'bold' },
+                headerTitle: language === 'tr' ? 'Gizlilik Politikası' : 'Privacy Policy',
+              }}
+            />
+            <Stack.Screen
+              name="TermsOfService"
+              component={TermsOfServiceScreen}
+              options={{
+                headerShown: true,
+                headerStyle: { backgroundColor: '#007AFF' },
+                headerTintColor: '#fff',
+                headerTitleStyle: { fontWeight: 'bold' },
+                headerTitle: language === 'tr' ? 'Kullanım Koşulları' : 'Terms of Service',
               }}
             />
           </>

--- a/LingRootMobile/src/screens/CreateScreen.tsx
+++ b/LingRootMobile/src/screens/CreateScreen.tsx
@@ -700,6 +700,55 @@ const CreateScreen: React.FC = () => {
         } else {
           const code = (response as any)?.code;
           const msg = response.message || t('create.alerts.audioCreateFailed');
+          
+          // Free Trial limit aşımı için özel yönlendirme
+          if (code === 'FREE_TRIAL_EXHAUSTED') {
+            const details = (response as any)?.details;
+            Alert.alert(
+              language === 'tr' ? 'Ücretsiz Deneme Bitti' : 'Free Trial Ended',
+              language === 'tr'
+                ? `${details?.audioCreationCount || 3} ses oluşturma hakkınızı kullandınız.\n\nDevam etmek için premium pakete geçin.`
+                : `You've used your ${details?.audioCreationCount || 3} audio creation credits.\n\nUpgrade to premium to continue.`,
+              [
+                {
+                  text: language === 'tr' ? 'Paketleri Gör' : 'View Packages',
+                  onPress: () => {
+                    navigation.navigate('Packages' as never);
+                  },
+                },
+                {
+                  text: language === 'tr' ? 'İptal' : 'Cancel',
+                  style: 'cancel',
+                },
+              ]
+            );
+            return;
+          }
+          
+          // Free Trial için metin çok uzun hatası
+          if (code === 'FREE_TRIAL_TEXT_TOO_LONG') {
+            const details = (response as any)?.details;
+            Alert.alert(
+              language === 'tr' ? 'Metin Çok Uzun' : 'Text Too Long',
+              language === 'tr'
+                ? `Ücretsiz denemede her ses maksimum ${details?.maxMinutes || 10} dakika olabilir.\n\nMetniniz: ~${details?.estimatedMinutes || 0} dakika\n\nLütfen metni kısaltın veya premium pakete geçin.`
+                : `In free trial, each audio can be maximum ${details?.maxMinutes || 10} minutes.\n\nYour text: ~${details?.estimatedMinutes || 0} minutes\n\nPlease shorten the text or upgrade to premium.`,
+              [
+                {
+                  text: language === 'tr' ? 'Paketleri Gör' : 'View Packages',
+                  onPress: () => {
+                    navigation.navigate('Packages' as never);
+                  },
+                },
+                {
+                  text: language === 'tr' ? 'Tamam' : 'OK',
+                  style: 'cancel',
+                },
+              ]
+            );
+            return;
+          }
+          
           if (code === 'NO_ACTIVE_PLAN' || code === 'USAGE_LIMIT_EXCEEDED') {
             Alert.alert(
               t('common.error'),

--- a/LingRootMobile/src/screens/PackagesScreen.tsx
+++ b/LingRootMobile/src/screens/PackagesScreen.tsx
@@ -12,7 +12,7 @@ import {
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import { useNavigation } from '@react-navigation/native';
 import { useLanguage } from '../contexts/LanguageContext';
-import { IAP_PRODUCTS, requestSubscription } from '../services/iap';
+import { IAP_PRODUCTS, requestSubscription, restorePurchases } from '../services/iap';
 import { apiService } from '../services/api';
 
 interface SubscriptionPlan {
@@ -38,6 +38,7 @@ const PackagesScreen: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [purchasingPlanId, setPurchasingPlanId] = useState<number | null>(null);
   const [activePackageName, setActivePackageName] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
 
   useEffect(() => {
     fetchPlans();
@@ -110,7 +111,10 @@ const PackagesScreen: React.FC = () => {
           [
             {
               text: 'Tamam',
-              onPress: () => navigation.goBack(),
+              onPress: () => {
+                fetchActivePackage(); // Refresh active package
+                navigation.goBack();
+              },
             },
           ]
         );
@@ -121,6 +125,47 @@ const PackagesScreen: React.FC = () => {
       Alert.alert('Hata', error.message || 'Satın alma sırasında bir hata oluştu');
     } finally {
       setPurchasingPlanId(null);
+    }
+  };
+
+  const handleRestore = async () => {
+    setRestoring(true);
+    try {
+      const result = await restorePurchases();
+      
+      if (result.ok) {
+        Alert.alert(
+          language === 'tr' ? 'Başarılı' : 'Success',
+          result.message || (language === 'tr' 
+            ? 'Satın alımlarınız başarıyla geri yüklendi' 
+            : 'Your purchases have been restored successfully'),
+          [
+            {
+              text: language === 'tr' ? 'Tamam' : 'OK',
+              onPress: () => {
+                fetchActivePackage(); // Refresh active package
+                fetchPlans(); // Refresh plans
+              },
+            },
+          ]
+        );
+      } else {
+        Alert.alert(
+          language === 'tr' ? 'Bilgi' : 'Info',
+          result.message || (language === 'tr'
+            ? 'Geri yüklenecek satın alım bulunamadı'
+            : 'No purchases found to restore')
+        );
+      }
+    } catch (error: any) {
+      Alert.alert(
+        language === 'tr' ? 'Hata' : 'Error',
+        error.message || (language === 'tr'
+          ? 'Geri yükleme sırasında bir hata oluştu'
+          : 'An error occurred during restore')
+      );
+    } finally {
+      setRestoring(false);
     }
   };
 
@@ -285,6 +330,54 @@ const PackagesScreen: React.FC = () => {
             </Text>
           </View>
         )}
+
+        {/* Restore Purchases Button */}
+        <View style={styles.restoreContainer}>
+          <TouchableOpacity
+            style={styles.restoreButton}
+            onPress={handleRestore}
+            disabled={restoring}
+          >
+            {restoring ? (
+              <ActivityIndicator size="small" color="#007AFF" />
+            ) : (
+              <>
+                <Icon name="restore" size={20} color="#007AFF" />
+                <Text style={styles.restoreButtonText}>
+                  {language === 'tr' ? 'Satın Alımları Geri Yükle' : 'Restore Purchases'}
+                </Text>
+              </>
+            )}
+          </TouchableOpacity>
+          <Text style={styles.restoreHint}>
+            {language === 'tr'
+              ? 'Daha önce satın aldığınız paketleri geri yükleyin'
+              : 'Restore your previously purchased packages'}
+          </Text>
+        </View>
+
+        {/* Apple Required Subscription Terms */}
+        <View style={styles.termsContainer}>
+          <Text style={styles.termsText}>
+            {language === 'tr'
+              ? '• Ödeme, satın alma onaylandığında iTunes Hesabınızdan tahsil edilecektir.\n\n• Abonelik, mevcut dönem bitmeden en az 24 saat önce iptal edilmediği sürece otomatik olarak yenilenir.\n\n• Hesabınız, mevcut dönem sona ermeden 24 saat içinde yenileme için ücretlendirilecektir.\n\n• Abonelikler kullanıcı tarafından yönetilebilir ve otomatik yenileme, satın alma sonrasında kullanıcının Hesap Ayarlarına gidilerek kapatılabilir.\n\n• Ücretsiz deneme süresinin kullanılmayan kısmı, varsa, kullanıcı o yayına abone olduğunda kaybedilecektir.'
+              : '• Payment will be charged to iTunes Account at confirmation of purchase.\n\n• Subscription automatically renews unless auto-renew is turned off at least 24-hours before the end of the current period.\n\n• Account will be charged for renewal within 24-hours prior to the end of the current period.\n\n• Subscriptions may be managed by the user and auto-renewal may be turned off by going to the user\'s Account Settings after purchase.\n\n• Any unused portion of a free trial period, if offered, will be forfeited when the user purchases a subscription to that publication.'}
+          </Text>
+          
+          <View style={styles.legalLinks}>
+            <TouchableOpacity onPress={() => (navigation as any).navigate('PrivacyPolicy')}>
+              <Text style={styles.legalLink}>
+                {language === 'tr' ? 'Gizlilik Politikası' : 'Privacy Policy'}
+              </Text>
+            </TouchableOpacity>
+            <Text style={styles.legalSeparator}>•</Text>
+            <TouchableOpacity onPress={() => (navigation as any).navigate('TermsOfService')}>
+              <Text style={styles.legalLink}>
+                {language === 'tr' ? 'Kullanım Şartları' : 'Terms of Service'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );
@@ -459,6 +552,71 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#FFFFFF',
     marginLeft: 6,
+  },
+  restoreContainer: {
+    marginHorizontal: 16,
+    marginTop: 24,
+    marginBottom: 16,
+    alignItems: 'center',
+  },
+  restoreButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    backgroundColor: '#F0F9FF',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#007AFF',
+    minHeight: 48,
+    gap: 8,
+  },
+  restoreButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#007AFF',
+    marginLeft: 8,
+  },
+  restoreHint: {
+    fontSize: 12,
+    color: '#6B7280',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  termsContainer: {
+    marginHorizontal: 16,
+    marginTop: 16,
+    marginBottom: 24,
+    padding: 16,
+    backgroundColor: '#F9FAFB',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  termsText: {
+    fontSize: 11,
+    color: '#6B7280',
+    lineHeight: 16,
+    textAlign: 'left',
+  },
+  legalLinks: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 16,
+    gap: 8,
+  },
+  legalLink: {
+    fontSize: 12,
+    color: '#007AFF',
+    fontWeight: '600',
+    textDecorationLine: 'underline',
+  },
+  legalSeparator: {
+    fontSize: 12,
+    color: '#9CA3AF',
+    marginHorizontal: 8,
   },
 });
 

--- a/LingRootMobile/src/screens/PrivacyPolicyScreen.tsx
+++ b/LingRootMobile/src/screens/PrivacyPolicyScreen.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const PrivacyPolicyScreen: React.FC = () => {
+  const { language } = useLanguage();
+
+  const contentTR = `
+GİZLİLİK POLİTİKASI
+
+Son Güncelleme: 6 Ekim 2025
+
+LingRoot olarak gizliliğinize önem veriyoruz. Bu gizlilik politikası, kişisel bilgilerinizi nasıl topladığımızı, kullandığımızı ve koruduğumuzu açıklar.
+
+1. TOPLANAN BİLGİLER
+
+1.1. Hesap Bilgileri
+• Ad ve soyad
+• E-posta adresi
+• Telefon numarası
+• Şifre (şifrelenmiş olarak saklanır)
+
+1.2. Kullanım Verileri
+• Oluşturduğunuz ses dosyaları
+• Metin içerikleri
+• Kelime listeleri ve çalışma geçmişi
+• Uygulama kullanım istatistikleri
+• Cihaz bilgileri (model, işletim sistemi)
+
+1.3. Ödeme Bilgileri
+• Abonelik bilgileri
+• Apple App Store üzerinden yapılan ödemeler (Apple tarafından işlenir)
+• Ödeme geçmişi
+
+2. BİLGİLERİN KULLANIMI
+
+Topladığımız bilgileri şu amaçlarla kullanırız:
+• Hizmetlerimizi sağlamak ve geliştirmek
+• Ses dosyaları oluşturmak (Google Text-to-Speech API)
+• Metin çevirileri yapmak (OpenAI API)
+• Kelime önerileri ve CEFR seviye belirleme (OpenAI API)
+• Hesap güvenliğini sağlamak
+• Müşteri desteği sunmak
+• Yasal yükümlülükleri yerine getirmek
+
+3. ÜÇÜNCÜ TARAF HİZMETLER
+
+Aşağıdaki üçüncü taraf hizmetlerini kullanıyoruz:
+• Google Text-to-Speech API (ses oluşturma)
+• OpenAI API (metin işleme, çeviri, seviye belirleme)
+• Apple App Store (ödeme işlemleri)
+• Supabase (veri saklama)
+
+Bu hizmetler kendi gizlilik politikalarına tabidir.
+
+4. VERİ GÜVENLİĞİ
+
+• Tüm veriler şifrelenmiş bağlantılar (HTTPS) üzerinden iletilir
+• Şifreler bcrypt ile hash'lenerek saklanır
+• Veritabanı erişimi güvenli kimlik doğrulama ile korunur
+• Düzenli güvenlik güncellemeleri yapılır
+
+5. VERİ SAKLAMA
+
+• Hesap bilgileriniz hesabınızı silene kadar saklanır
+• Ses dosyaları ve içerikler hesabınızla ilişkili olarak saklanır
+• Kullanım istatistikleri analiz amacıyla saklanır
+
+6. HAKLARINIZ
+
+• Kişisel verilerinize erişim hakkı
+• Verilerinizi düzeltme hakkı
+• Verilerinizi silme hakkı (hesap silme)
+• Veri taşınabilirliği hakkı
+• İtiraz etme hakkı
+
+7. ÇOCUKLARIN GİZLİLİĞİ
+
+Hizmetimiz 13 yaş altı çocuklara yönelik değildir. Bilerek 13 yaş altı çocuklardan kişisel bilgi toplamıyoruz.
+
+8. DEĞİŞİKLİKLER
+
+Bu gizlilik politikasını zaman zaman güncelleyebiliriz. Önemli değişiklikler e-posta ile bildirilecektir.
+
+9. İLETİŞİM
+
+Gizlilik ile ilgili sorularınız için:
+E-posta: support@lingroot.com
+Web: https://lingroot.com
+
+KVKK kapsamındaki haklarınızı kullanmak için yukarıdaki iletişim bilgilerinden bize ulaşabilirsiniz.
+`;
+
+  const contentEN = `
+PRIVACY POLICY
+
+Last Updated: October 6, 2025
+
+At LingRoot, we value your privacy. This privacy policy explains how we collect, use, and protect your personal information.
+
+1. INFORMATION WE COLLECT
+
+1.1. Account Information
+• Full name
+• Email address
+• Phone number
+• Password (stored encrypted)
+
+1.2. Usage Data
+• Audio files you create
+• Text content
+• Vocabulary lists and study history
+• App usage statistics
+• Device information (model, operating system)
+
+1.3. Payment Information
+• Subscription details
+• Payments made through Apple App Store (processed by Apple)
+• Payment history
+
+2. HOW WE USE YOUR INFORMATION
+
+We use the collected information for:
+• Providing and improving our services
+• Creating audio files (Google Text-to-Speech API)
+• Text translations (OpenAI API)
+• Word suggestions and CEFR level determination (OpenAI API)
+• Account security
+• Customer support
+• Legal compliance
+
+3. THIRD-PARTY SERVICES
+
+We use the following third-party services:
+• Google Text-to-Speech API (audio creation)
+• OpenAI API (text processing, translation, level determination)
+• Apple App Store (payment processing)
+• Supabase (data storage)
+
+These services are subject to their own privacy policies.
+
+4. DATA SECURITY
+
+• All data is transmitted over encrypted connections (HTTPS)
+• Passwords are hashed using bcrypt
+• Database access is protected with secure authentication
+• Regular security updates are performed
+
+5. DATA RETENTION
+
+• Your account information is stored until you delete your account
+• Audio files and content are stored associated with your account
+• Usage statistics are retained for analysis purposes
+
+6. YOUR RIGHTS
+
+• Right to access your personal data
+• Right to correct your data
+• Right to delete your data (account deletion)
+• Right to data portability
+• Right to object
+
+7. CHILDREN'S PRIVACY
+
+Our service is not directed to children under 13. We do not knowingly collect personal information from children under 13.
+
+8. CHANGES
+
+We may update this privacy policy from time to time. Significant changes will be notified via email.
+
+9. CONTACT
+
+For privacy-related questions:
+Email: support@lingroot.com
+Web: https://lingroot.com
+
+You can contact us using the above information to exercise your rights under applicable data protection laws.
+`;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.content}>
+        <Text style={styles.text}>
+          {language === 'tr' ? contentTR : contentEN}
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  text: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: '#374151',
+  },
+});
+
+export default PrivacyPolicyScreen;

--- a/LingRootMobile/src/screens/TermsOfServiceScreen.tsx
+++ b/LingRootMobile/src/screens/TermsOfServiceScreen.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const TermsOfServiceScreen: React.FC = () => {
+  const { language } = useLanguage();
+
+  const contentTR = `
+KULLANIM ŞARTLARI
+
+Son Güncelleme: 6 Ekim 2025
+
+LingRoot mobil uygulamasını kullanarak aşağıdaki şartları kabul etmiş olursunuz.
+
+1. HİZMET TANIMI
+
+LingRoot, İngilizce öğrenenler için yapay zeka destekli metin-sese dönüştürme, kelime öğrenme ve içerik oluşturma hizmeti sunar.
+
+2. HESAP OLUŞTURMA
+
+• 13 yaş ve üzeri kullanıcılar hesap oluşturabilir
+• Doğru ve güncel bilgiler sağlamalısınız
+• Hesap güvenliğinden siz sorumlusunuz
+• Hesabınızı başkalarıyla paylaşamazsınız
+
+3. ABONELİK VE ÖDEMELER
+
+3.1. Ücretsiz Deneme
+• Yeni kullanıcılara 3 ses oluşturma hakkı verilir
+• Her ses maksimum 10 dakika olabilir
+• Deneme hakkı bittikten sonra premium pakete geçiş gerekir
+
+3.2. Premium Paketler
+• Gold Plan: ₺399/ay
+• Platinum Plan: ₺599/ay
+• Ödemeler Apple App Store üzerinden işlenir
+• Abonelikler otomatik olarak yenilenir
+• İptal etmek için iOS Ayarlar > Apple ID > Abonelikler'den yönetebilirsiniz
+
+3.3. İade Politikası
+• İadeler Apple'ın iade politikasına tabidir
+• İade talepleri Apple App Store üzerinden yapılmalıdır
+
+4. KULLANIM KURALLARI
+
+Aşağıdaki davranışlar yasaktır:
+• Yasadışı içerik oluşturma
+• Telif hakkı ihlali yapan içerikler
+• Spam veya kötüye kullanım
+• Hizmeti tersine mühendislik ile inceleme
+• Otomatik sistemler (botlar) kullanma
+
+5. FİKRİ MÜLKİYET
+
+• LingRoot markası ve logosu şirketimize aittir
+• Oluşturduğunuz içerikler size aittir
+• Hizmeti sağlamak için içeriklerinizi işleme hakkımız vardır
+• Üçüncü taraf API'ler (Google TTS, OpenAI) kendi şartlarına tabidir
+
+6. HİZMET SINIRLAMALARI
+
+• Hizmet "olduğu gibi" sunulur
+• Kesintisiz hizmet garantisi vermiyoruz
+• Teknik sorunlar yaşanabilir
+• API limitleri uygulanır
+
+7. SORUMLULUK SINIRI
+
+• Hizmet kesintilerinden sorumlu değiliz
+• Veri kaybından sorumlu değiliz
+• Üçüncü taraf hizmetlerden kaynaklanan sorunlardan sorumlu değiliz
+• Maksimum sorumluluk ödediğiniz ücretle sınırlıdır
+
+8. HİZMET DEĞİŞİKLİKLERİ
+
+• Hizmeti değiştirme veya sonlandırma hakkımız saklıdır
+• Fiyatları değiştirme hakkımız saklıdır
+• Önemli değişiklikler önceden bildirilir
+
+9. HESAP ASKIYA ALMA VE SONLANDIRMA
+
+Aşağıdaki durumlarda hesabınızı askıya alabilir veya sonlandırabiliriz:
+• Kullanım şartlarını ihlal
+• Yasadışı aktiviteler
+• Kötüye kullanım
+• Ödeme sorunları
+
+10. UYGULANACAK HUKUK
+
+Bu şartlar Türkiye Cumhuriyeti yasalarına tabidir.
+
+11. DEĞİŞİKLİKLER
+
+Bu kullanım şartlarını zaman zaman güncelleyebiliriz. Önemli değişiklikler e-posta ile bildirilecektir.
+
+12. İLETİŞİM
+
+Sorularınız için:
+E-posta: support@lingroot.com
+Web: https://lingroot.com
+`;
+
+  const contentEN = `
+TERMS OF SERVICE
+
+Last Updated: October 6, 2025
+
+By using the LingRoot mobile application, you agree to these terms.
+
+1. SERVICE DESCRIPTION
+
+LingRoot provides AI-powered text-to-speech, vocabulary learning, and content creation services for English learners.
+
+2. ACCOUNT CREATION
+
+• Users must be 13 years or older
+• You must provide accurate and current information
+• You are responsible for account security
+• You may not share your account with others
+
+3. SUBSCRIPTIONS AND PAYMENTS
+
+3.1. Free Trial
+• New users receive 3 audio creation credits
+• Each audio can be up to 10 minutes
+• Premium upgrade required after trial credits are used
+
+3.2. Premium Plans
+• Gold Plan: ₺399/month
+• Platinum Plan: ₺599/month
+• Payments are processed through Apple App Store
+• Subscriptions automatically renew
+• Cancel anytime via iOS Settings > Apple ID > Subscriptions
+
+3.3. Refund Policy
+• Refunds are subject to Apple's refund policy
+• Refund requests must be made through Apple App Store
+
+4. USAGE RULES
+
+The following behaviors are prohibited:
+• Creating illegal content
+• Copyright infringement
+• Spam or abuse
+• Reverse engineering the service
+• Using automated systems (bots)
+
+5. INTELLECTUAL PROPERTY
+
+• LingRoot brand and logo are owned by our company
+• Content you create belongs to you
+• We have the right to process your content to provide the service
+• Third-party APIs (Google TTS, OpenAI) are subject to their own terms
+
+6. SERVICE LIMITATIONS
+
+• Service is provided "as is"
+• We do not guarantee uninterrupted service
+• Technical issues may occur
+• API limits apply
+
+7. LIMITATION OF LIABILITY
+
+• We are not liable for service interruptions
+• We are not liable for data loss
+• We are not liable for issues caused by third-party services
+• Maximum liability is limited to the amount you paid
+
+8. SERVICE CHANGES
+
+• We reserve the right to modify or terminate the service
+• We reserve the right to change prices
+• Significant changes will be notified in advance
+
+9. ACCOUNT SUSPENSION AND TERMINATION
+
+We may suspend or terminate your account for:
+• Violation of terms of service
+• Illegal activities
+• Abuse
+• Payment issues
+
+10. GOVERNING LAW
+
+These terms are governed by the laws of the Republic of Turkey.
+
+11. CHANGES
+
+We may update these terms from time to time. Significant changes will be notified via email.
+
+12. CONTACT
+
+For questions:
+Email: support@lingroot.com
+Web: https://lingroot.com
+`;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.content}>
+        <Text style={styles.text}>
+          {language === 'tr' ? contentTR : contentEN}
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  text: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: '#374151',
+  },
+});
+
+export default TermsOfServiceScreen;

--- a/LingRootMobile/src/types/index.ts
+++ b/LingRootMobile/src/types/index.ts
@@ -122,6 +122,8 @@ export type RootStackParamList = {
   Packages: undefined;
   Chat: undefined;
   Vocabulary: { wordId?: string } | undefined;
+  PrivacyPolicy: undefined;
+  TermsOfService: undefined;
 };
 
 export type MainTabParamList = {

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -216,31 +216,33 @@ exports.register = async (req, res) => {
     const token = generateToken(newUser[0].id, newUser[0].email, newUser[0].role, false);
     const refreshToken = generateRefreshToken(newUser[0].id);
 
-    // Assign default free trial plan if exists
+    // Assign Free Trial plan (3 audio creation credits)
     try {
       const { data: trialPlan, error: planErr } = await supabase
         .from('subscription_plans')
         .select('*')
-        .eq('is_trial', true)
+        .eq('name', 'Free Trial')
         .eq('is_active', true)
-        .order('price', { ascending: true })
-        .limit(1)
         .maybeSingle();
+      
       if (!planErr && trialPlan) {
+        // Trial süresiz - sadece 3 ses oluşturma hakkı
         await supabase
           .from('subscriptions')
           .insert([
             {
               user_id: newUser[0].id,
               plan_id: trialPlan.id,
-              status: 'trialing',
-              current_period_end: new Date(Date.now() + (Number(trialPlan.trial_days || 7) * 24 * 60 * 60 * 1000)).toISOString(),
+              status: 'active', // Trial değil, aktif - kullanım hakkı bazlı
+              current_period_end: new Date(Date.now() + (365 * 24 * 60 * 60 * 1000)).toISOString(), // 1 yıl (süresiz gibi)
               cancel_at_period_end: false,
+              audio_creation_count: 0, // Başlangıç sayacı
             },
           ]);
+        logger.info(`[REGISTER] Free Trial plan assigned to user ${newUser[0].id}`);
       }
     } catch (e) {
-      logger.warn('[REGISTER] Failed to assign trial plan:', e?.message);
+      logger.warn('[REGISTER] Failed to assign Free Trial plan:', e?.message);
     }
 
     // Send registration notification to support team
@@ -566,31 +568,33 @@ exports.googleLogin = async (req, res) => {
         logger.warn('[GOOGLE_LOGIN] Registration notification failed:', notificationErr?.message);
       }
       
-      // Assign default free trial plan if exists for Google new users
+      // Assign Free Trial plan (3 audio creation credits) for Google new users
       try {
         const { data: trialPlan, error: planErr } = await supabase
           .from('subscription_plans')
           .select('*')
-          .eq('is_trial', true)
+          .eq('name', 'Free Trial')
           .eq('is_active', true)
-          .order('price', { ascending: true })
-          .limit(1)
           .maybeSingle();
+        
         if (!planErr && trialPlan) {
+          // Trial süresiz - sadece 3 ses oluşturma hakkı
           await supabase
             .from('subscriptions')
             .insert([
               {
                 user_id: user.id,
                 plan_id: trialPlan.id,
-                status: 'trialing',
-                current_period_end: new Date(Date.now() + (Number(trialPlan.trial_days || 7) * 24 * 60 * 60 * 1000)).toISOString(),
+                status: 'active', // Trial değil, aktif - kullanım hakkı bazlı
+                current_period_end: new Date(Date.now() + (365 * 24 * 60 * 60 * 1000)).toISOString(), // 1 yıl (süresiz gibi)
                 cancel_at_period_end: false,
+                audio_creation_count: 0, // Başlangıç sayacı
               },
             ]);
+          logger.info(`[GOOGLE_LOGIN] Free Trial plan assigned to user ${user.id}`);
         }
       } catch (e2) {
-        logger.warn('[GOOGLE_LOGIN] Failed to assign trial plan:', e2?.message);
+        logger.warn('[GOOGLE_LOGIN] Failed to assign Free Trial plan:', e2?.message);
       }
     }
 

--- a/backend/controllers/subscriptionController.js
+++ b/backend/controllers/subscriptionController.js
@@ -834,11 +834,18 @@ exports.getUsageSummary = async (req, res) => {
       data: {
         hasPlan: true,
         subscription: state.subscription,
+        plan: state.plan,
+        plantype: state.plan?.name,
         periodStart: state.periodStart,
         usage: state.usage,
         limits: state.limits,
         exceeded: state.exceeded,
         isExceeded: state.isExceeded,
+        // Free Trial özel alanları
+        isFreeTrialExhausted: state.isFreeTrialExhausted || false,
+        audioCreationCount: state.audioCreationCount,
+        maxAudioCount: state.maxAudioCount,
+        remainingAudioCount: state.remainingAudioCount,
       },
     });
   } catch (e) {

--- a/backend/controllers/ttsController.js
+++ b/backend/controllers/ttsController.js
@@ -297,9 +297,46 @@ const processTtsRequest = async (req, res) => {
                 expiredAt: limitState?.expiredAt,
               });
             }
+            
+            // Free Trial için tek ses başına 10 dk (10,000 karakter) limiti
+            if (limitState.plan?.name === 'Free Trial') {
+              const textLength = adaptedText.length;
+              const maxCharsPerAudio = 10000; // 10 dakika
+              
+              if (textLength > maxCharsPerAudio) {
+                logger.warn(`[${requestId}] Free Trial text too long: ${textLength} > ${maxCharsPerAudio}`);
+                return res.status(200).json({
+                  success: false,
+                  code: 'FREE_TRIAL_TEXT_TOO_LONG',
+                  message: `Ücretsiz deneme ile her ses maksimum ${Math.floor(maxCharsPerAudio / 1000)} dakika olabilir. Metniniz ${Math.ceil(textLength / 1000)} dakika. Lütfen metni kısaltın veya premium pakete geçin.`,
+                  details: {
+                    textLength,
+                    maxLength: maxCharsPerAudio,
+                    estimatedMinutes: Math.ceil(textLength / 1000),
+                    maxMinutes: Math.floor(maxCharsPerAudio / 1000),
+                  },
+                });
+              }
+            }
+            
             // If plan exists but limits exceeded, block
             if (limitState.isExceeded) {
               logger.warn(`[${requestId}] Usage limit exceeded for user ${userId}`);
+              
+              // Free Trial özel mesajı
+              if (limitState.isFreeTrialExhausted) {
+                return res.status(200).json({
+                  success: false,
+                  code: 'FREE_TRIAL_EXHAUSTED',
+                  message: limitState.message || 'Ücretsiz deneme hakkınız doldu. Premium pakete geçin.',
+                  details: {
+                    audioCreationCount: limitState.audioCreationCount,
+                    maxAudioCount: limitState.maxAudioCount,
+                    planName: 'Free Trial',
+                  },
+                });
+              }
+              
               return res.status(200).json({
                 success: false,
                 code: 'USAGE_LIMIT_EXCEEDED',
@@ -1040,6 +1077,32 @@ const processTtsRequest = async (req, res) => {
                 
                 logger.info(`[${requestId}] ✅ Audio saved to contenthistory table: ${data[0]?.id}`);
                 logger.info(`[${requestId}] 📊 Saved data:`, JSON.stringify(data[0], null, 2));
+                
+                // Free Trial için ses oluşturma sayacını artır
+                try {
+                    const { data: activeSub } = await supabase
+                        .from('subscriptions')
+                        .select('id, plan_id, audio_creation_count, subscription_plans!inner(name)')
+                        .eq('user_id', userId)
+                        .eq('status', 'active')
+                        .order('created_at', { ascending: false })
+                        .limit(1)
+                        .maybeSingle();
+                    
+                    if (activeSub && activeSub.subscription_plans?.name === 'Free Trial') {
+                        const currentCount = Number(activeSub.audio_creation_count || 0);
+                        await supabase
+                            .from('subscriptions')
+                            .update({ 
+                                audio_creation_count: currentCount + 1,
+                                updated_at: new Date().toISOString()
+                            })
+                            .eq('id', activeSub.id);
+                        logger.info(`[${requestId}] 🎯 Free Trial counter updated: ${currentCount} -> ${currentCount + 1}`);
+                    }
+                } catch (counterErr) {
+                    logger.warn(`[${requestId}] Failed to update Free Trial counter:`, counterErr?.message);
+                }
             } else {
                 logger.warn(`[${requestId}] ⚠️ No user ID found, skipping contenthistory save`);
                 logger.warn(`[${requestId}] 🔍 Auth header: ${authHeader ? 'present' : 'missing'}`);

--- a/backend/migrations/0027_add_free_trial_plan.sql
+++ b/backend/migrations/0027_add_free_trial_plan.sql
@@ -1,0 +1,45 @@
+-- Add Free Trial plan with 3 audio creation limit
+-- This plan will be automatically assigned to new users after email verification
+
+INSERT INTO subscription_plans (
+  name,
+  description,
+  price,
+  interval,
+  features,
+  is_active,
+  is_trial,
+  trial_days,
+  monthly_cost_limit_usd,
+  openai_token_limit,
+  tts_char_limit,
+  apple_product_id,
+  created_at,
+  updated_at
+) VALUES (
+  'Free Trial',
+  'Ücretsiz deneme paketi - 3 ses oluşturma hakkı (her biri 10 dk)',
+  0,
+  'trial',
+  '["TR: 3 ses oluşturma hakkı", "EN: 3 audio creation credits", "TR: Her ses maksimum 10 dakika", "EN: Each audio up to 10 minutes", "TR: Tüm CEFR seviyeleri", "EN: All CEFR levels", "TR: Kelime ekleme", "EN: Vocabulary addition"]'::jsonb,
+  true,
+  true,
+  999, -- Gün limiti yok, kullanım hakkı bazlı
+  0, -- Maliyet limiti yok (Free Trial için USD kontrolü yapılmayacak)
+  30000, -- OpenAI token limiti (3 x 10 dk için yeterli)
+  30000, -- TTS karakter limiti: 3 hak x 10,000 karakter (10 dk) = 30,000 karakter
+  NULL, -- Apple product ID yok (ücretsiz)
+  NOW(),
+  NOW()
+)
+ON CONFLICT DO NOTHING;
+
+-- Add audio_creation_count column to subscriptions table to track trial usage
+ALTER TABLE subscriptions 
+ADD COLUMN IF NOT EXISTS audio_creation_count INTEGER DEFAULT 0;
+
+-- Add index for faster queries
+CREATE INDEX IF NOT EXISTS idx_subscriptions_audio_count ON subscriptions(audio_creation_count);
+
+-- Comment explaining the system
+COMMENT ON COLUMN subscriptions.audio_creation_count IS 'Tracks number of audio files created under this subscription. Used for Free Trial limit (3 audios).';

--- a/backend/migrations/0028_update_free_plan_to_trial.sql
+++ b/backend/migrations/0028_update_free_plan_to_trial.sql
@@ -1,0 +1,39 @@
+-- Update existing "Free Plan" to proper "Free Trial" with usage-based limits
+-- This converts the time-based trial to usage-based (3 audio creation credits)
+
+UPDATE subscription_plans
+SET
+  name = 'Free Trial',
+  description = 'Ücretsiz deneme paketi - 3 ses oluşturma hakkı (her biri 10 dk)',
+  price = 0,
+  interval = 'monthly',
+  features = '["TR: 3 ses oluşturma hakkı", "EN: 3 audio creation credits", "TR: Her ses maksimum 10 dakika", "EN: Each audio up to 10 minutes", "TR: Tüm CEFR seviyeleri", "EN: All CEFR levels", "TR: Kelime ekleme", "EN: Vocabulary addition"]'::jsonb,
+  is_active = true,
+  is_trial = true,
+  trial_days = 999, -- Gün limiti yok, kullanım hakkı bazlı
+  monthly_cost_limit_usd = 0, -- Maliyet limiti yok (Free Trial için USD kontrolü yapılmayacak)
+  openai_token_limit = 30000, -- OpenAI token limiti (3 x 10 dk için yeterli)
+  tts_char_limit = 30000, -- TTS karakter limiti: 3 hak x 10,000 karakter (10 dk) = 30,000 karakter
+  apple_product_id = NULL, -- Apple product ID yok (ücretsiz)
+  updated_at = NOW()
+WHERE id = '88b38204-e22b-45b8-8043-4b8013462186'; -- Mevcut Free Plan ID
+
+-- Add audio_creation_count column to subscriptions table to track trial usage
+ALTER TABLE subscriptions 
+ADD COLUMN IF NOT EXISTS audio_creation_count INTEGER DEFAULT 0;
+
+-- Update existing Free Plan subscriptions to reset their audio counter
+UPDATE subscriptions
+SET 
+  audio_creation_count = 0,
+  status = 'active', -- 'trialing' yerine 'active' (kullanım hakkı bazlı)
+  current_period_end = NOW() + INTERVAL '1 year', -- Süresiz (1 yıl)
+  updated_at = NOW()
+WHERE plan_id = '88b38204-e22b-45b8-8043-4b8013462186'
+  AND status IN ('active', 'trialing');
+
+-- Add index for faster queries
+CREATE INDEX IF NOT EXISTS idx_subscriptions_audio_count ON subscriptions(audio_creation_count);
+
+-- Comment explaining the system
+COMMENT ON COLUMN subscriptions.audio_creation_count IS 'Tracks number of audio files created under this subscription. Used for Free Trial limit (3 audios).';

--- a/backend/migrations/query_current_plans.sql
+++ b/backend/migrations/query_current_plans.sql
@@ -1,0 +1,48 @@
+-- Query to view current subscription plans and their limits
+SELECT 
+  id,
+  name,
+  description,
+  price,
+  interval,
+  is_active,
+  is_trial,
+  trial_days,
+  -- Limitler
+  monthly_cost_limit_usd,
+  openai_token_limit,
+  tts_char_limit,
+  -- Apple IAP
+  apple_product_id,
+  -- Özellikler
+  features,
+  -- Tarihler
+  created_at,
+  updated_at
+FROM subscription_plans
+WHERE is_active = true
+ORDER BY 
+  CASE 
+    WHEN name = 'Free Trial' THEN 1
+    WHEN name = 'Gold' THEN 2
+    WHEN name = 'Platinum' THEN 3
+    ELSE 4
+  END;
+
+-- Aktif kullanıcı aboneliklerini görmek için:
+-- SELECT 
+--   s.id,
+--   s.user_id,
+--   u.email,
+--   u.full_name,
+--   sp.name as plan_name,
+--   s.status,
+--   s.audio_creation_count,
+--   s.current_period_start,
+--   s.current_period_end
+-- FROM subscriptions s
+-- JOIN users u ON u.id = s.user_id
+-- JOIN subscription_plans sp ON sp.id = s.plan_id
+-- WHERE s.status = 'active'
+-- ORDER BY s.created_at DESC
+-- LIMIT 20;

--- a/backend/scripts/check_plans.js
+++ b/backend/scripts/check_plans.js
@@ -1,0 +1,68 @@
+// Script to check current subscription plans in database
+const { supabase } = require('../utils/supabaseClient');
+
+async function checkPlans() {
+  try {
+    console.log('🔍 Fetching subscription plans from database...\n');
+    
+    const { data: plans, error } = await supabase
+      .from('subscription_plans')
+      .select('*')
+      .eq('is_active', true)
+      .order('price', { ascending: true });
+    
+    if (error) {
+      console.error('❌ Error fetching plans:', error);
+      return;
+    }
+    
+    if (!plans || plans.length === 0) {
+      console.log('⚠️  No active plans found in database');
+      return;
+    }
+    
+    console.log(`✅ Found ${plans.length} active plan(s):\n`);
+    console.log('='.repeat(100));
+    
+    plans.forEach((plan, index) => {
+      console.log(`\n📦 Plan ${index + 1}: ${plan.name}`);
+      console.log('-'.repeat(100));
+      console.log(`  ID:                    ${plan.id}`);
+      console.log(`  Description:           ${plan.description || 'N/A'}`);
+      console.log(`  Price:                 ₺${plan.price}`);
+      console.log(`  Interval:              ${plan.interval}`);
+      console.log(`  Is Trial:              ${plan.is_trial ? 'Yes' : 'No'}`);
+      console.log(`  Trial Days:            ${plan.trial_days || 'N/A'}`);
+      console.log('');
+      console.log('  📊 LIMITS:');
+      console.log(`  - Monthly Cost (USD):  ${plan.monthly_cost_limit_usd !== null ? '$' + plan.monthly_cost_limit_usd : 'Unlimited'}`);
+      console.log(`  - OpenAI Tokens:       ${plan.openai_token_limit !== null ? plan.openai_token_limit.toLocaleString() : 'Unlimited'}`);
+      console.log(`  - TTS Characters:      ${plan.tts_char_limit !== null ? plan.tts_char_limit.toLocaleString() : 'Unlimited'}`);
+      console.log('');
+      console.log('  🍎 APPLE IAP:');
+      console.log(`  - Product ID:          ${plan.apple_product_id || 'Not set'}`);
+      console.log('');
+      console.log('  ✨ FEATURES:');
+      if (plan.features && Array.isArray(plan.features)) {
+        plan.features.forEach(feature => {
+          console.log(`     - ${feature}`);
+        });
+      } else {
+        console.log('     No features listed');
+      }
+      console.log('');
+      console.log(`  📅 Created:            ${new Date(plan.created_at).toLocaleString('tr-TR')}`);
+      console.log(`  📅 Updated:            ${new Date(plan.updated_at).toLocaleString('tr-TR')}`);
+    });
+    
+    console.log('\n' + '='.repeat(100));
+    console.log('\n✅ Plan check completed!\n');
+    
+  } catch (error) {
+    console.error('❌ Error:', error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+checkPlans();

--- a/backend/scripts/compare_limits.js
+++ b/backend/scripts/compare_limits.js
@@ -1,0 +1,100 @@
+// Script to compare Gold vs Platinum limits calculation
+const { supabase } = require('../utils/supabaseClient');
+
+async function compareLimits() {
+  try {
+    console.log('🔍 Comparing Gold vs Platinum limit calculations...\n');
+    
+    // Get plans
+    const { data: plans } = await supabase
+      .from('subscription_plans')
+      .select('*')
+      .in('name', ['Gold Plan', 'Platin Plan'])
+      .order('price', { ascending: true });
+    
+    if (!plans || plans.length < 2) {
+      console.log('❌ Could not find both plans');
+      return;
+    }
+    
+    const goldPlan = plans.find(p => p.name.toLowerCase().includes('gold'));
+    const platinPlan = plans.find(p => p.name.toLowerCase().includes('platin'));
+    
+    console.log('📦 GOLD PLAN');
+    console.log('='.repeat(80));
+    console.log(`Price (TRY):              ₺${goldPlan.price}`);
+    console.log(`TTS Char Limit (DB):      ${goldPlan.tts_char_limit || 'NULL (Unlimited)'}`);
+    console.log(`OpenAI Token Limit (DB):  ${goldPlan.openai_token_limit || 'NULL (Unlimited)'}`);
+    console.log(`Monthly USD Limit (DB):   ${goldPlan.monthly_cost_limit_usd || 'NULL (Unlimited)'}`);
+    console.log('');
+    
+    // Hesaplanan USD budget (1/3 rule)
+    const usdTryRate = 40; // Varsayılan kur
+    const goldUsdBudget = Number(((goldPlan.price / usdTryRate) / 3).toFixed(2));
+    console.log('💰 COMPUTED USD BUDGET (1/3 rule):');
+    console.log(`Formula: (₺${goldPlan.price} / ${usdTryRate}) / 3 = $${goldUsdBudget}`);
+    console.log('');
+    
+    // Her kategori için kalan karakter hesapla
+    const COST_PER_1K = {
+      standard: 0.004,
+      neural2: 0.016,
+      wavenet: 0.004,
+      studio: 0.16,
+      chirp3d: 0.03,
+    };
+    
+    console.log('📊 REMAINING CHARACTERS BY CATEGORY (if $0 used):');
+    Object.entries(COST_PER_1K).forEach(([cat, cost]) => {
+      const remainingChars = Math.floor((goldUsdBudget * 1000) / cost);
+      const videoMinutes = Math.floor(remainingChars / 1000);
+      const pages = Math.floor(remainingChars / 2000);
+      console.log(`  ${cat.padEnd(10)}: ${remainingChars.toLocaleString()} chars (~${videoMinutes} min, ~${pages} pages)`);
+    });
+    
+    console.log('\n\n📦 PLATINUM PLAN');
+    console.log('='.repeat(80));
+    console.log(`Price (TRY):              ₺${platinPlan.price}`);
+    console.log(`TTS Char Limit (DB):      ${platinPlan.tts_char_limit || 'NULL (Unlimited)'}`);
+    console.log(`OpenAI Token Limit (DB):  ${platinPlan.openai_token_limit || 'NULL (Unlimited)'}`);
+    console.log(`Monthly USD Limit (DB):   ${platinPlan.monthly_cost_limit_usd || 'NULL (Unlimited)'}`);
+    console.log('');
+    
+    const platinUsdBudget = Number(((platinPlan.price / usdTryRate) / 3).toFixed(2));
+    console.log('💰 COMPUTED USD BUDGET (1/3 rule):');
+    console.log(`Formula: (₺${platinPlan.price} / ${usdTryRate}) / 3 = $${platinUsdBudget}`);
+    console.log('');
+    
+    console.log('📊 REMAINING CHARACTERS BY CATEGORY (if $0 used):');
+    Object.entries(COST_PER_1K).forEach(([cat, cost]) => {
+      const remainingChars = Math.floor((platinUsdBudget * 1000) / cost);
+      const videoMinutes = Math.floor(remainingChars / 1000);
+      const pages = Math.floor(remainingChars / 2000);
+      console.log(`  ${cat.padEnd(10)}: ${remainingChars.toLocaleString()} chars (~${videoMinutes} min, ~${pages} pages)`);
+    });
+    
+    console.log('\n\n🔍 COMPARISON');
+    console.log('='.repeat(80));
+    console.log(`Gold USD Budget:     $${goldUsdBudget}`);
+    console.log(`Platinum USD Budget: $${platinUsdBudget}`);
+    console.log(`Difference:          $${(platinUsdBudget - goldUsdBudget).toFixed(2)} (${Math.round((platinUsdBudget / goldUsdBudget - 1) * 100)}% more)`);
+    console.log('');
+    
+    // Standard kategorisi için karşılaştırma
+    const goldStandardChars = Math.floor((goldUsdBudget * 1000) / COST_PER_1K.standard);
+    const platinStandardChars = Math.floor((platinUsdBudget * 1000) / COST_PER_1K.standard);
+    console.log('Standard Voice Category:');
+    console.log(`  Gold:     ${goldStandardChars.toLocaleString()} chars (~${Math.floor(goldStandardChars / 1000)} min)`);
+    console.log(`  Platinum: ${platinStandardChars.toLocaleString()} chars (~${Math.floor(platinStandardChars / 1000)} min)`);
+    console.log(`  Diff:     ${(platinStandardChars - goldStandardChars).toLocaleString()} chars (~${Math.floor((platinStandardChars - goldStandardChars) / 1000)} min more)`);
+    
+    console.log('\n✅ Comparison completed!\n');
+    
+  } catch (error) {
+    console.error('❌ Error:', error);
+  } finally {
+    process.exit(0);
+  }
+}
+
+compareLimits();

--- a/backend/utils/usageLimiter.js
+++ b/backend/utils/usageLimiter.js
@@ -144,6 +144,38 @@ async function checkLimits(userId) {
       return { hasPlan: false };
     }
     const plan = subscription.plan || null;
+    
+    // Free Trial özel kontrolü - ses oluşturma sayısı bazlı
+    if (plan?.name === 'Free Trial') {
+      const audioCount = Number(subscription.audio_creation_count || 0);
+      const maxAudioCount = 3;
+      
+      if (audioCount >= maxAudioCount) {
+        logger.warn(`[USAGE LIMIT] Free Trial limit reached for user ${userId}. Created: ${audioCount}/${maxAudioCount}`);
+        return {
+          hasPlan: true,
+          subscription,
+          plan,
+          isExceeded: true,
+          isFreeTrialExhausted: true,
+          audioCreationCount: audioCount,
+          maxAudioCount,
+          message: 'Ücretsiz deneme hakkınız doldu. Premium pakete geçin.',
+        };
+      }
+      
+      return {
+        hasPlan: true,
+        subscription,
+        plan,
+        isExceeded: false,
+        isFreeTrialExhausted: false,
+        audioCreationCount: audioCount,
+        maxAudioCount,
+        remainingAudioCount: maxAudioCount - audioCount,
+      };
+    }
+    
     const periodStart = getPeriodStart(subscription, plan);
     const periodEnd = subscription?.current_period_end || subscription?.enddate || subscription?.endDate || new Date(new Date(periodStart).getTime() + (plan?.interval === 'yearly' ? 365 : 30) * 24 * 60 * 60 * 1000).toISOString();
     


### PR DESCRIPTION
✅ Free Trial System:
- Migrated from time-based to usage-based trial (3 audio credits)
- Added audio_creation_count tracking to subscriptions
- Updated Free Plan to Free Trial with proper limits
- Each trial audio limited to 10 minutes

✅ Apple IAP Compliance:
- Added Restore Purchases button to PackagesScreen
- Added all required Apple subscription legal terms
- Created PrivacyPolicyScreen with TR/EN content
- Created TermsOfServiceScreen with TR/EN content
- Added navigation from PackagesScreen to legal pages
- Updated AppNavigator with PrivacyPolicy and TermsOfService routes

✅ Backend Updates:
- Updated authController for trial plan assignment
- Updated subscriptionController for usage-based limits
- Updated ttsController for audio creation tracking
- Updated usageLimiter for Free Trial validation
- Added migration scripts for plan updates

✅ UI/UX Improvements:
- Enhanced UsageEstimateCard with trial info
- Improved CreateScreen trial limit handling
- Better error messages for trial users

This release includes all critical requirements for Apple App Store submission.