### PR TITLE
fix: Free Trial system improvements

### DIFF
--- a/LingRootMobile/src/screens/PackagesScreen.tsx
+++ b/LingRootMobile/src/screens/PackagesScreen.tsx
@@ -53,10 +53,12 @@ const PackagesScreen: React.FC = () => {
       console.log('Plans response:', response);
       
       if (response.success && Array.isArray(response.data)) {
-        // Sadece aktif paketleri göster
-        const activePlans = response.data.filter((p: SubscriptionPlan) => p.is_active);
-        console.log('Active plans:', activePlans.length, activePlans);
-        setPlans(activePlans);
+        // Sadece aktif ve satın alınabilir paketleri göster (Free Trial hariç)
+        const purchasablePlans = response.data.filter((p: SubscriptionPlan) => 
+          p.is_active && p.apple_product_id // Sadece Apple Product ID'si olan paketler
+        );
+        console.log('Purchasable plans:', purchasablePlans.length, purchasablePlans);
+        setPlans(purchasablePlans);
       } else {
         console.log('Invalid response format:', response);
         Alert.alert('Hata', 'Paket verisi alınamadı');

--- a/backend/controllers/ttsController.js
+++ b/backend/controllers/ttsController.js
@@ -1080,25 +1080,32 @@ const processTtsRequest = async (req, res) => {
                 
                 // Free Trial için ses oluşturma sayacını artır
                 try {
-                    const { data: activeSub } = await supabase
+                    const { data: activeSub, error: subError } = await supabase
                         .from('subscriptions')
-                        .select('id, plan_id, audio_creation_count, subscription_plans!inner(name)')
+                        .select('id, plantype, audio_creation_count')
                         .eq('user_id', userId)
                         .eq('status', 'active')
                         .order('created_at', { ascending: false })
                         .limit(1)
                         .maybeSingle();
                     
-                    if (activeSub && activeSub.subscription_plans?.name === 'Free Trial') {
+                    if (subError) {
+                        logger.warn(`[${requestId}] Error fetching subscription for counter update:`, subError.message);
+                    } else if (activeSub && activeSub.plantype === 'Free Trial') {
                         const currentCount = Number(activeSub.audio_creation_count || 0);
-                        await supabase
+                        const { error: updateError } = await supabase
                             .from('subscriptions')
                             .update({ 
                                 audio_creation_count: currentCount + 1,
                                 updated_at: new Date().toISOString()
                             })
                             .eq('id', activeSub.id);
-                        logger.info(`[${requestId}] 🎯 Free Trial counter updated: ${currentCount} -> ${currentCount + 1}`);
+                        
+                        if (updateError) {
+                            logger.warn(`[${requestId}] Failed to update Free Trial counter:`, updateError.message);
+                        } else {
+                            logger.info(`[${requestId}] 🎯 Free Trial counter updated: ${currentCount} -> ${currentCount + 1}`);
+                        }
                     }
                 } catch (counterErr) {
                     logger.warn(`[${requestId}] Failed to update Free Trial counter:`, counterErr?.message);

--- a/backend/migrations/assign_free_trial_to_user.sql
+++ b/backend/migrations/assign_free_trial_to_user.sql
@@ -1,0 +1,104 @@
+-- Assign Free Trial to specific user: mobile.androdi.tr@gmail.com
+-- This script will:
+-- 1. Find the user by email
+-- 2. Get the Free Trial plan ID
+-- 3. Create or update their subscription to Free Trial
+
+-- First, let's check if user exists and get their ID
+DO $$
+DECLARE
+  v_user_id UUID;
+  v_plan_id UUID;
+  v_existing_sub_id UUID;
+BEGIN
+  -- Get user ID
+  SELECT id INTO v_user_id
+  FROM users
+  WHERE email = 'mobile.androdi.tr@gmail.com';
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'User not found with email: mobile.androdi.tr@gmail.com';
+  END IF;
+
+  RAISE NOTICE 'Found user ID: %', v_user_id;
+
+  -- Get Free Trial plan ID
+  SELECT id INTO v_plan_id
+  FROM subscription_plans
+  WHERE name = 'Free Trial' AND is_active = true;
+
+  IF v_plan_id IS NULL THEN
+    RAISE EXCEPTION 'Free Trial plan not found';
+  END IF;
+
+  RAISE NOTICE 'Found Free Trial plan ID: %', v_plan_id;
+
+  -- Check if user already has a subscription
+  SELECT id INTO v_existing_sub_id
+  FROM subscriptions
+  WHERE user_id = v_user_id
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_existing_sub_id IS NOT NULL THEN
+    -- Update existing subscription
+    RAISE NOTICE 'Updating existing subscription ID: %', v_existing_sub_id;
+    
+    UPDATE subscriptions
+    SET
+      plan_id = v_plan_id,
+      status = 'active',
+      audio_creation_count = 0, -- Reset audio count
+      current_period_start = NOW(),
+      current_period_end = NOW() + INTERVAL '1 year', -- Süresiz (1 yıl)
+      updated_at = NOW()
+    WHERE id = v_existing_sub_id;
+
+    RAISE NOTICE 'Subscription updated successfully';
+  ELSE
+    -- Create new subscription
+    RAISE NOTICE 'Creating new subscription for user';
+    
+    INSERT INTO subscriptions (
+      user_id,
+      plan_id,
+      status,
+      audio_creation_count,
+      current_period_start,
+      current_period_end,
+      created_at,
+      updated_at
+    ) VALUES (
+      v_user_id,
+      v_plan_id,
+      'active',
+      0, -- Start with 0 audio count
+      NOW(),
+      NOW() + INTERVAL '1 year', -- Süresiz (1 yıl)
+      NOW(),
+      NOW()
+    );
+
+    RAISE NOTICE 'Subscription created successfully';
+  END IF;
+
+  -- Show final result
+  RAISE NOTICE '✅ Free Trial assigned successfully to mobile.androdi.tr@gmail.com';
+  RAISE NOTICE 'User has 3 audio creation credits (10 minutes each)';
+END $$;
+
+-- Verify the subscription
+SELECT 
+  u.email,
+  u.full_name,
+  sp.name as plan_name,
+  s.status,
+  s.audio_creation_count,
+  s.current_period_start,
+  s.current_period_end
+FROM subscriptions s
+JOIN users u ON u.id = s.user_id
+JOIN subscription_plans sp ON sp.id = s.plan_id
+WHERE u.email = 'mobile.androdi.tr@gmail.com'
+ORDER BY s.created_at DESC
+LIMIT 1;

--- a/backend/migrations/check_subscriptions_schema.sql
+++ b/backend/migrations/check_subscriptions_schema.sql
@@ -1,0 +1,9 @@
+-- Check subscriptions table structure
+SELECT 
+    column_name,
+    data_type,
+    is_nullable,
+    column_default
+FROM information_schema.columns
+WHERE table_name = 'subscriptions'
+ORDER BY ordinal_position;

--- a/backend/migrations/run_on_supabase.sql
+++ b/backend/migrations/run_on_supabase.sql
@@ -1,0 +1,117 @@
+-- ============================================
+-- SUPABASE SQL EDITOR'DA ÇALIŞTIR
+-- ============================================
+-- Bu script Free Trial sistemini kurar ve mobile.android.tr@gmail.com kullanıcısına atar
+
+-- 1. audio_creation_count kolonunu ekle (eğer yoksa)
+ALTER TABLE subscriptions 
+ADD COLUMN IF NOT EXISTS audio_creation_count INTEGER DEFAULT 0;
+
+-- 2. Index ekle
+CREATE INDEX IF NOT EXISTS idx_subscriptions_audio_count ON subscriptions(audio_creation_count);
+
+-- 3. Kolon açıklaması ekle
+COMMENT ON COLUMN subscriptions.audio_creation_count IS 'Tracks number of audio files created under this subscription. Used for Free Trial limit (3 audios).';
+
+-- 4. Free Trial planını kontrol et ve güncelle
+UPDATE subscription_plans
+SET
+  name = 'Free Trial',
+  description = 'Ücretsiz deneme paketi - 3 ses oluşturma hakkı (her biri 10 dk)',
+  price = 0,
+  interval = 'monthly',
+  features = '["TR: 3 ses oluşturma hakkı", "EN: 3 audio creation credits", "TR: Her ses maksimum 10 dakika", "EN: Each audio up to 10 minutes", "TR: Tüm CEFR seviyeleri", "EN: All CEFR levels", "TR: Kelime ekleme", "EN: Vocabulary addition"]'::jsonb,
+  is_active = true,
+  is_trial = true,
+  trial_days = 999,
+  monthly_cost_limit_usd = 0,
+  openai_token_limit = 30000,
+  tts_char_limit = 30000,
+  apple_product_id = NULL,
+  updated_at = NOW()
+WHERE id = '88b38204-e22b-45b8-8043-4b8013462186';
+
+-- 5. mobile.android.tr@gmail.com kullanıcısına Free Trial ata
+DO $$
+DECLARE
+  v_user_id UUID;
+  v_existing_sub_id UUID;
+BEGIN
+  -- Kullanıcı ID'sini al
+  SELECT id INTO v_user_id
+  FROM users
+  WHERE email = 'mobile.android.tr@gmail.com';
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'User not found: mobile.android.tr@gmail.com';
+  END IF;
+
+  RAISE NOTICE 'Found user ID: %', v_user_id;
+
+  -- Mevcut aboneliği kontrol et
+  SELECT id INTO v_existing_sub_id
+  FROM subscriptions
+  WHERE user_id = v_user_id
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_existing_sub_id IS NOT NULL THEN
+    -- Mevcut aboneliği güncelle
+    RAISE NOTICE 'Updating existing subscription ID: %', v_existing_sub_id;
+    
+    UPDATE subscriptions
+    SET
+      plantype = 'Free Trial',
+      status = 'active',
+      audio_creation_count = 0,
+      startdate = NOW(),
+      enddate = NOW() + INTERVAL '1 year',
+      updated_at = NOW()
+    WHERE id = v_existing_sub_id;
+
+    RAISE NOTICE '✅ Subscription updated successfully';
+  ELSE
+    -- Yeni abonelik oluştur
+    RAISE NOTICE 'Creating new subscription for user';
+    
+    INSERT INTO subscriptions (
+      user_id,
+      plantype,
+      status,
+      audio_creation_count,
+      startdate,
+      enddate,
+      created_at,
+      updated_at
+    ) VALUES (
+      v_user_id,
+      'Free Trial',
+      'active',
+      0,
+      NOW(),
+      NOW() + INTERVAL '1 year',
+      NOW(),
+      NOW()
+    );
+
+    RAISE NOTICE '✅ Subscription created successfully';
+  END IF;
+
+  RAISE NOTICE '🎉 Free Trial assigned to mobile.android.tr@gmail.com';
+END $$;
+
+-- 6. Sonucu doğrula
+SELECT 
+  u.email,
+  u.firstname,
+  u.lastname,
+  s.plantype,
+  s.status,
+  s.audio_creation_count,
+  s.startdate,
+  s.enddate
+FROM subscriptions s
+JOIN users u ON u.id = s.user_id
+WHERE u.email = 'mobile.android.tr@gmail.com'
+ORDER BY s.created_at DESC
+LIMIT 1;

--- a/backend/scripts/assign_free_trial.js
+++ b/backend/scripts/assign_free_trial.js
@@ -1,0 +1,138 @@
+// Script to assign Free Trial to a specific user
+// Usage: node backend/scripts/assign_free_trial.js mobile.androdi.tr@gmail.com
+
+require('dotenv').config();
+const { supabase } = require('../utils/supabaseClient');
+
+async function assignFreeTrial(email) {
+  try {
+    console.log(`🔍 Looking for user: ${email}`);
+
+    // 1. Find user
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .select('id, email')
+      .eq('email', email)
+      .single();
+
+    if (userError || !user) {
+      console.error('❌ User not found:', userError?.message);
+      process.exit(1);
+    }
+
+    console.log(`✅ Found user: ${user.email} (${user.id})`);
+
+    // 2. Get Free Trial plan
+    const { data: plan, error: planError } = await supabase
+      .from('subscription_plans')
+      .select('id, name')
+      .eq('name', 'Free Trial')
+      .eq('is_active', true)
+      .single();
+
+    if (planError || !plan) {
+      console.error('❌ Free Trial plan not found:', planError?.message);
+      process.exit(1);
+    }
+
+    console.log(`✅ Found plan: ${plan.name} (${plan.id})`);
+
+    // 3. Check existing subscription
+    const { data: existingSub } = await supabase
+      .from('subscriptions')
+      .select('id, status, audio_creation_count')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existingSub) {
+      console.log(`📝 Updating existing subscription: ${existingSub.id}`);
+      console.log(`   Current status: ${existingSub.status}`);
+      console.log(`   Current audio count: ${existingSub.audio_creation_count || 0}`);
+
+      // Update existing subscription
+      const { error: updateError } = await supabase
+        .from('subscriptions')
+        .update({
+          plan_id: plan.id,
+          status: 'active',
+          audio_creation_count: 0, // Reset to 0
+          current_period_start: new Date().toISOString(),
+          current_period_end: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(), // 1 year
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingSub.id);
+
+      if (updateError) {
+        console.error('❌ Error updating subscription:', updateError.message);
+        process.exit(1);
+      }
+
+      console.log('✅ Subscription updated successfully');
+    } else {
+      console.log('📝 Creating new subscription');
+
+      // Create new subscription
+      const { error: insertError } = await supabase
+        .from('subscriptions')
+        .insert({
+          user_id: user.id,
+          plan_id: plan.id,
+          status: 'active',
+          audio_creation_count: 0,
+          current_period_start: new Date().toISOString(),
+          current_period_end: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+
+      if (insertError) {
+        console.error('❌ Error creating subscription:', insertError.message);
+        process.exit(1);
+      }
+
+      console.log('✅ Subscription created successfully');
+    }
+
+    // 4. Verify final state
+    const { data: finalSub } = await supabase
+      .from('subscriptions')
+      .select(`
+        id,
+        status,
+        audio_creation_count,
+        current_period_start,
+        current_period_end,
+        plan:subscription_plans(name)
+      `)
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    console.log('\n🎉 Free Trial assigned successfully!');
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log(`User: ${email}`);
+    console.log(`Plan: ${finalSub.plan?.name || 'Free Trial'}`);
+    console.log(`Status: ${finalSub.status}`);
+    console.log(`Audio Credits: ${finalSub.audio_creation_count || 0} / 3`);
+    console.log(`Valid Until: ${new Date(finalSub.current_period_end).toLocaleDateString()}`);
+    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+  } catch (error) {
+    console.error('❌ Unexpected error:', error.message);
+    process.exit(1);
+  }
+}
+
+// Get email from command line argument
+const email = process.argv[2];
+
+if (!email) {
+  console.error('❌ Usage: node assign_free_trial.js <email>');
+  console.error('   Example: node assign_free_trial.js mobile.androdi.tr@gmail.com');
+  process.exit(1);
+}
+
+assignFreeTrial(email);

--- a/backend/scripts/check_user.js
+++ b/backend/scripts/check_user.js
@@ -1,0 +1,20 @@
+// Check if user exists
+require('dotenv').config();
+const { supabase } = require('../utils/supabaseClient');
+
+async function checkUser(email) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('email', email);
+
+  if (error) {
+    console.error('Error:', error.message);
+    return;
+  }
+
+  console.log(`Found ${data.length} user(s) with email: ${email}`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+checkUser('mobile.android.tr@gmail.com');


### PR DESCRIPTION
- Fixed PackagesScreen to hide Free Trial from purchasable plans (only show plans with apple_product_id)
- Fixed ttsController audio_creation_count tracking to use plantype instead of plan_id join
- Added SQL scripts for Free Trial management:
  - assign_free_trial_to_user.sql: Assign Free Trial to specific user
  - run_on_supabase.sql: Complete Free Trial setup for Supabase
  - check_subscriptions_schema.sql: View subscriptions table structure
- Added helper scripts:
  - assign_free_trial.js: Node script to assign Free Trial via CLI
  - check_user.js: Check user existence and details

Free Trial now properly tracks audio creation count and limits users to 3 audio files.